### PR TITLE
追加:chatsマイグレーションファイルの実装をする

### DIFF
--- a/database/migrations/2023_07_23_162410_create_chats_table.php
+++ b/database/migrations/2023_07_23_162410_create_chats_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('chats', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('group_id');
+            $table->foreignId('user_id');
+            $table->text('message');
+            $table->timestamp('updated_at')->useCurrent();
+            $table->timestamp('created_at')->useCurrent();
+            $table->softDeletes()->default(null);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('chats');
+    }
+};


### PR DESCRIPTION
チャット用のグループを管理するgroupsテーブルとリレーションするためのgroup_idカラムの追加
ユーザーを管理するusersテーブルとリレーションするためのuser_idカラムの追加
メッセージを管理するためのmesseageカラムの追加
updated_at、created_atの初期値をnullから現在時刻へ変更
論理削除処理を可能にするためのsoftDeletesカラムの追加