### PR TITLE
修正：前回コミットのヘッダーの編集が反映されていなかったため再度修正、授業詳細画面の曜日表示欄の修正、時間割画面の表示内容をする

### DIFF
--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -14,10 +14,10 @@ for($period = 1; $period < 7; $period++){
                 break;
             }
             
-            $timetable .= '<th></th>';
-            
         }
-    
+        
+        $timetable .= '<th></th>';
+        
     }
     $timetable .= '</tr>';
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,7 +15,7 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
-                    <x-nav-link href="/">
+                    <x-nav-link href="/lectures/{{ Auth::user()->id }}">
                         {{ __('時間割へ') }}
                     </x-nav-link>
                     <x-nav-link href="/tasks/index/{{ Auth::user()->id }}">
@@ -23,6 +23,9 @@
                     </x-nav-link>
                     <x-nav-link href="/groups/{{ Auth::user()->id }}/index">
                         {{ __('グループの一覧へ') }}
+                    </x-nav-link>
+                    <x-nav-link :href="route('calendars')" :active="request()->routeIs('calendars')">
+                        {{ __('カレンダーへ') }}
                     </x-nav-link>
                 </div>
             </div>

--- a/resources/views/lectures/detail.blade.php
+++ b/resources/views/lectures/detail.blade.php
@@ -1,3 +1,28 @@
+<?php
+
+switch($lecture->day_of_week){
+    case 0:
+        $day_of_week = '月曜日';
+        break;
+    case 1:
+        $day_of_week = '火曜日';
+        break;
+    case 2:
+        $day_of_week = '水曜日';
+        break;
+    case 3:
+        $day_of_week = '木曜日';
+        break;
+    case 4:
+        $day_of_week = '金曜日';
+        break;
+    case 5:
+        $day_of_week = '土曜日';
+        break;
+}
+    
+
+?>
 <!DOCTYPE html>
 <html>
     
@@ -20,7 +45,7 @@
                     <p>{{ $lecture->period }}時限目</p>
                 </div>
                 <div class="detail_day_of_week">
-                    <p>{{ $lecture->period }}</p>
+                    <p><?php echo $day_of_week ?></p>
                 </div>
                 <div class="detail_classroom">
                     <p>{{ $lecture->classroom }}</p>


### PR DESCRIPTION
ヘッダーファイルに関しては前回コミットと同様の内容を実装
授業詳細画面においては曜日欄に曜日が表示されるようにphp分を追加
時間割画面においては正常な位置に表示されていなかったため正常な位置に表示されるように修正